### PR TITLE
[DM-3921] Add public repo and ceph support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,3 @@
 logs
 pkg
 Gemfile.lock
-vendor
-
-# Emacs
-#*#
-*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.bundle
 .env
 .DS_Store
 logs
 pkg
 Gemfile.lock
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ logs
 pkg
 Gemfile.lock
 vendor
+
+# Emacs
+#*#
+*~

--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ If you are bundling the service inside of another application, such as Rails, or
 You can also hook the authentication into your own service this way. For example:
 
 ``` ruby
-GitLfsS3::Application.on_authenticate do |username, password|
-  user = User.find(username: username)
-  user.verify_password(password)
+GitLfsS3::Application.on_authenticate do |username, password, is_safe|
+  if is_safe
+    true
+  else
+    user = User.find(username: username)
+    user.verify_password(password)
+  end
 end
 ```
 

--- a/bin/git-lfs-s3
+++ b/bin/git-lfs-s3
@@ -11,7 +11,19 @@ GitLfsS3::Application.set :s3_bucket, ENV['S3_BUCKET']
 GitLfsS3::Application.set :server_url, ENV['LFS_SERVER_URL']
 GitLfsS3::Application.set :public_server, (ENV['LFS_PUBLIC_SERVER'] == 'true')
 GitLfsS3::Application.set :ceph_s3, (ENV['LFS_CEPH_S3'] == 'true')
+GitLfsS3::Application.set :endpoint, ENV['LFS_CEPH_ENDPOINT']
 GitLfsS3::Application.set :logger, Logger.new(STDOUT)
+
+if GitLfsS3::Application.settings.ceph_s3
+  Aws.config.update(
+    endpoint: ENV['LFS_CEPH_ENDPOINT'],
+    access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+    secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+    force_path_style: true,
+    region: 'us-east-1',
+    # ssl_ca_bundle: '/usr/local/etc/openssl/cert.pem' # Required for brew install on a mac.
+  )
+end
 
 GitLfsS3::Application.on_authenticate do |username, password, is_safe|
   if is_safe # Whether the HTTP method is safe (GET, HEAD)

--- a/bin/git-lfs-s3
+++ b/bin/git-lfs-s3
@@ -10,6 +10,7 @@ GitLfsS3::Application.set :aws_secret_access_key, ENV['AWS_SECRET_ACCESS_KEY']
 GitLfsS3::Application.set :s3_bucket, ENV['S3_BUCKET']
 GitLfsS3::Application.set :server_url, ENV['LFS_SERVER_URL']
 GitLfsS3::Application.set :public_server, (ENV['LFS_PUBLIC_SERVER'] == 'true')
+GitLfsS3::Application.set :ceph_s3, (ENV['LFS_CEPH_S3'] == 'true')
 GitLfsS3::Application.set :logger, Logger.new(STDOUT)
 
 GitLfsS3::Application.on_authenticate do |username, password, is_safe|

--- a/bin/git-lfs-s3
+++ b/bin/git-lfs-s3
@@ -11,8 +11,12 @@ GitLfsS3::Application.set :s3_bucket, ENV['S3_BUCKET']
 GitLfsS3::Application.set :server_url, ENV['LFS_SERVER_URL']
 GitLfsS3::Application.set :logger, Logger.new(STDOUT)
 
-GitLfsS3::Application.on_authenticate do |username, password|
-  username == ENV['USERNAME'] && password == ENV['PASSWORD']
+GitLfsS3::Application.on_authenticate do |username, password, is_safe|
+  if is_safe # Whether the HTTP method is safe (GET, HEAD)
+    true
+  else
+    username == ENV['USERNAME'] && password == ENV['PASSWORD']
+  end
 end
 
 Rack::Handler::WEBrick.run(

--- a/bin/git-lfs-s3
+++ b/bin/git-lfs-s3
@@ -9,6 +9,7 @@ GitLfsS3::Application.set :aws_access_key_id, ENV['AWS_ACCESS_KEY_ID']
 GitLfsS3::Application.set :aws_secret_access_key, ENV['AWS_SECRET_ACCESS_KEY']
 GitLfsS3::Application.set :s3_bucket, ENV['S3_BUCKET']
 GitLfsS3::Application.set :server_url, ENV['LFS_SERVER_URL']
+GitLfsS3::Application.set :public_server, (ENV['LFS_PUBLIC_SERVER'] == 'true')
 GitLfsS3::Application.set :logger, Logger.new(STDOUT)
 
 GitLfsS3::Application.on_authenticate do |username, password, is_safe|

--- a/git-lfs-s3.gemspec
+++ b/git-lfs-s3.gemspec
@@ -4,13 +4,13 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'git-lfs-s3/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "git-lfs-s3"
+  gem.name          = "lsst-git-lfs-s3"
   gem.version       = GitLfsS3::VERSION
-  gem.authors       = ["Ryan LeFevre"]
-  gem.email         = ["meltingice8917@gmail.com"]
-  gem.description   = %q{A Git LFS server that uses S3 for the storage backend.}
-  gem.summary       = %q{A Git LFS server that uses S3 for the storage backend by providing presigned S3 URLs.}
-  gem.homepage      = "https://github.com/meltingice/git-lfs-s3"
+  gem.authors       = ["Ryan LeFevre", "J. Matt Peterson"]
+  gem.email         = ["meltingice8917@gmail.com", "jmatt@lsst.org"]
+  gem.description   = %q{LSST's Git LFS server that uses S3 for the storage backend.}
+  gem.summary       = %q{LSST's Git LFS server that uses S3 for the storage backend by providing presigned S3 URLs.}
+  gem.homepage      = "https://github.com/lsst-sqre/git-lfs-s3"
   gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split($/)
@@ -19,8 +19,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'aws-sdk', '~> 2'
-  gem.add_dependency 'sinatra'
-  gem.add_dependency 'multi_json'
+  gem.add_dependency 'sinatra', '~> 1'
+  gem.add_dependency 'multi_json', '~> 1'
 
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rake', '~> 10'
 end

--- a/lib/git-lfs-s3.rb
+++ b/lib/git-lfs-s3.rb
@@ -1,6 +1,6 @@
-require "sinatra/base"
-require "aws-sdk"
-require "multi_json"
+require 'sinatra/base'
+require 'aws-sdk'
+require 'multi_json'
 
 require "git-lfs-s3/aws"
 require "git-lfs-s3/services/upload"

--- a/lib/git-lfs-s3.rb
+++ b/lib/git-lfs-s3.rb
@@ -1,6 +1,6 @@
-require 'sinatra/base'
-require 'aws-sdk'
-require 'multi_json'
+require "sinatra/base"
+require "aws-sdk"
+require "multi_json"
 
 require "git-lfs-s3/aws"
 require "git-lfs-s3/services/upload"

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -91,7 +91,9 @@ module GitLfsS3
       data = MultiJson.load(request.body.tap { |b| b.rewind }.read)
       object = object_data(data['oid'])
       if settings.public_server and settings.ceph_s3
-        object.acl.put(acl: "public-read")
+        if object.exists?
+          object.acl.put(acl: "public-read")
+        end
       end
       if object.exists? && object.size == data['size']
         status 200

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -97,15 +97,16 @@ module GitLfsS3
     post '/verify', provides: 'application/vnd.git-lfs+json' do
       data = MultiJson.load(request.body.tap { |b| b.rewind }.read)
       object = object_data(data['oid'])
+      if not object.exists?
+        status 404
+      end
       if settings.public_server and settings.ceph_s3
-        if object.exists? and not object.acl.grants.include?(public_read_grant)
+        if object.acl.grants.include?(public_read_grant)
           object.acl.put(acl: "public-read")
         end
       end
-      if object.exists? && object.size == data['size']
+      if object.size == data['size']
         status 200
-      else
-        status 404
       end
     end
   end

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -75,7 +75,7 @@ module GitLfsS3
     end
 
     before do
-      pass if request.safe?
+      pass if request.safe? and settings.public_server
       protected!
     end
 

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -13,8 +13,8 @@ module GitLfsS3
         !auth_callback.nil?
       end
 
-      def perform_authentication(username, password)
-        auth_callback.call(username, password)
+      def perform_authentication(username, password, is_safe)
+        auth_callback.call(username, password, is_safe)
       end
     end
 
@@ -31,8 +31,9 @@ module GitLfsS3
 
     def authorized?
       @auth ||=  Rack::Auth::Basic::Request.new(request.env)
+      logger.debug request.safe?
       @auth.provided? && @auth.basic? && @auth.credentials && self.class.auth_callback.call(
-        @auth.credentials[0], @auth.credentials[1]
+        @auth.credentials[0], @auth.credentials[1], request.safe?
       )
     end
 

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -90,7 +90,9 @@ module GitLfsS3
     post '/verify', provides: 'application/vnd.git-lfs+json' do
       data = MultiJson.load(request.body.tap { |b| b.rewind }.read)
       object = object_data(data['oid'])
-      object.acl.put(acl: "public-read")
+      if settings.public_server and settings.ceph_s3
+        object.acl.put(acl: "public-read")
+      end
       if object.exists? && object.size == data['size']
         status 200
       else

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -31,7 +31,6 @@ module GitLfsS3
 
     def authorized?
       @auth ||=  Rack::Auth::Basic::Request.new(request.env)
-      logger.debug request.safe?
       @auth.provided? && @auth.basic? && @auth.credentials && self.class.auth_callback.call(
         @auth.credentials[0], @auth.credentials[1], request.safe?
       )

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -90,7 +90,7 @@ module GitLfsS3
     post '/verify', provides: 'application/vnd.git-lfs+json' do
       data = MultiJson.load(request.body.tap { |b| b.rewind }.read)
       object = object_data(data['oid'])
-
+      object.acl.put(acl: "public-read")
       if object.exists? && object.size == data['size']
         status 200
       else

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -36,16 +36,7 @@ module GitLfsS3
         @auth.credentials[0], @auth.credentials[1], request.safe?
       )
     end
-
-    def protected!
-      unless authorized?
-        response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
-        throw(:halt, [401, "Invalid username or password"])
-      end
-    end
-
-    before { protected! }
-
+    
     get '/' do
       "Git LFS S3 is online."
     end
@@ -74,6 +65,18 @@ module GitLfsS3
         status 404
         body MultiJson.dump({message: 'Object not found'})
       end
+    end
+    
+    def protected!
+      unless authorized?
+        response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
+        throw(:halt, [401, "Invalid username or password"])
+      end
+    end
+
+    before do
+      pass if request.safe?
+      protected!
     end
 
     post "/objects", provides: 'application/vnd.git-lfs+json' do

--- a/lib/git-lfs-s3/services/ceph_presigner.rb
+++ b/lib/git-lfs-s3/services/ceph_presigner.rb
@@ -1,4 +1,5 @@
 require 'base64'
+require 'date'
 require 'digest/sha1'
 require 'openssl'
 require 'uri'
@@ -14,10 +15,10 @@ module GitLfsS3
       access_key_id = Aws.config[:access_key_id]
       endpoint = Aws.config[:endpoint]
       digest = OpenSSL::Digest.new('sha1')
-      can_string = "PUT\n\n\n#{expire_date}\n/#{obj.bucket_name}/#{obj.key}"
+      can_string = "PUT\n\napplication/octet-stream\n#{expire_at}\n/#{obj.bucket_name}/#{obj.key}"
       hmac = OpenSSL::HMAC.digest(digest, secret_access_key, can_string)
       signature = URI.escape(Base64.encode64(hmac).strip, /[\+=?@$&,\/:;\?]/)
-      "#{endpoint}/#{obj.bucket_name}/#{obj.key}?Signature=#{signature}&AWSAccessKeyId=#{access_key_id}&Expires=#{expire_date}"
+      "#{endpoint}/#{obj.bucket_name}/#{obj.key}?Signature=#{signature}&AWSAccessKeyId=#{access_key_id}&Expires=#{expire_at}"
     end
   end
 end

--- a/lib/git-lfs-s3/services/ceph_presigner.rb
+++ b/lib/git-lfs-s3/services/ceph_presigner.rb
@@ -8,12 +8,12 @@ module GitLfsS3
   module CephPresignerService
     extend self
     extend AwsHelpers
-
+    
     def signed_url(obj)
       expire_at = (DateTime.now + 1).strftime("%s")
-      secret_access_key = Aws.config[:secret_access_key]
-      access_key_id = Aws.config[:access_key_id]
-      endpoint = Aws.config[:endpoint]
+      secret_access_key = GitLfsS3::Application.settings.aws_secret_access_key
+      access_key_id = GitLfsS3::Application.settings.aws_access_key_id
+      endpoint = GitLfsS3::Application.settings.endpoint
       digest = OpenSSL::Digest.new('sha1')
       can_string = "PUT\n\napplication/octet-stream\n#{expire_at}\n/#{obj.bucket_name}/#{obj.key}"
       hmac = OpenSSL::HMAC.digest(digest, secret_access_key, can_string)

--- a/lib/git-lfs-s3/services/ceph_presigner.rb
+++ b/lib/git-lfs-s3/services/ceph_presigner.rb
@@ -1,0 +1,23 @@
+require 'base64'
+require 'digest/sha1'
+require 'openssl'
+require 'uri'
+
+module GitLfsS3
+  module CephPresignerService
+    extend self
+    extend AwsHelpers
+
+    def signed_url(obj)
+      expire_at = (DateTime.now + 1).strftime("%s")
+      secret_access_key = Aws.config[:secret_access_key]
+      access_key_id = Aws.config[:access_key_id]
+      endpoint = Aws.config[:endpoint]
+      digest = OpenSSL::Digest.new('sha1')
+      can_string = "PUT\n\n\n#{expire_date}\n/#{obj.bucket_name}/#{obj.key}"
+      hmac = OpenSSL::HMAC.digest(digest, secret_access_key, can_string)
+      signature = URI.escape(Base64.encode64(hmac).strip, /[\+=?@$&,\/:;\?]/)
+      "#{endpoint}/#{obj.bucket_name}/#{obj.key}?Signature=#{signature}&AWSAccessKeyId=#{access_key_id}&Expires=#{expire_date}"
+    end
+  end
+end

--- a/lib/git-lfs-s3/services/upload/base.rb
+++ b/lib/git-lfs-s3/services/upload/base.rb
@@ -23,6 +23,10 @@ module GitLfsS3
       def server_url
         GitLfsS3::Application.settings.server_url
       end
+
+      def ceph_s3
+        GitLfsS3::Application.settings.ceph_s3
+      end
     end
   end
 end

--- a/lib/git-lfs-s3/services/upload/upload_required.rb
+++ b/lib/git-lfs-s3/services/upload/upload_required.rb
@@ -31,7 +31,11 @@ module GitLfsS3
         if ceph_s3
           GitLfsS3::CephPresignerService::signed_url(object)
         else
-          object.presigned_url(:put)
+          if GitLfsS3::Application.settings.public_server
+            object.presigned_url(:put, acl: 'public-read')
+          else
+            object.presigned_url(:put)
+          end
         end
       end
 

--- a/lib/git-lfs-s3/services/upload/upload_required.rb
+++ b/lib/git-lfs-s3/services/upload/upload_required.rb
@@ -1,3 +1,5 @@
+require "git-lfs-s3/services/ceph_presigner"
+
 module GitLfsS3
   module UploadService
     class UploadRequired < Base
@@ -26,7 +28,11 @@ module GitLfsS3
       private
 
       def upload_destination
-        object.presigned_url(:put)
+        if ceph_s3
+          GitLfsS3::CephPresignerService::signed_url(object)
+        else
+          object.presigned_url(:put)
+        end
       end
 
       def upload_headers

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.1.4'
+  VERSION = '0.2.0'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end


### PR DESCRIPTION
Add features required to use git-lfs-s3 as a public repo that uses [Ceph](http://ceph.com/) S3 (Hammer version).
## Public Server

LSST has a need to allow anonymous users to clone and pull git-lfs enabled git repos. This was implemented through adding an environment variable and adding another field to the auth callback.
- Add `LFS_PUBLIC_SERVER` environment variable to support anonymous users for safe operations such as git-clone or git-pull.
- Add `is_safe` field to the auth callback, this is used when the server should be public.
## Ceph

Our deployment currently uses [Ceph](http://ceph.com/) S3 (Hammer version). There are some features that their S3 clone lacks that directly affect the git-lfs server workflow. First, It doesn't apply ACLs passed in with a presigned URL. Second, the current AWS Signature v4 (and the older v2) do not work. The request parameters for these signatures are simply ignored. I've implemented the older presigner that looks similar to the Ceph S3 URLs found in their documentation. Additionally I've moved the ACL update to the verify method. If it's a public server and the object is not public, it'll be updated to `public-read`.
- Add `LFS_CEPH_S3` environment variable.
