### PR TITLE
[DM-5737] Implement the Git LFS Batch API.

### DIFF
--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module GitLfsS3
   class Application < Sinatra::Application
     include AwsHelpers
@@ -47,6 +49,145 @@ module GitLfsS3
       "Git LFS S3 is online."
     end
 
+    def valid_object?(object)
+      begin
+        valid = object[:size] >= 0
+      rescue
+        valid = false
+      end
+      begin        
+        if valid
+          oid = object[:oid].hex
+          valid = oid.size == 32 && object[:oid].size == 64
+        end
+      rescue
+        valid = false
+      end
+      valid
+    end
+
+    def object_download(authenticated, object, object_json)
+      oid = object_json[:oid]
+      size = object_json[:size]
+      {
+        'oid' => oid,
+        'size' => size,
+        'authenticated' => authenticated,
+        'actions' => {
+          'download' => {
+            'href' => object.presigned_url(:get, :expires_in => 86400)
+          }
+        },
+        'expires_at' => DateTime.now.next_day.to_time.utc.iso8601
+      }
+    end
+
+    def object_upload(authenticated, object, object_json)
+      # Format a single upload object.
+      oid = object_json[:oid]
+      size = object_json[:size]
+      {
+        'oid' => oid,
+        'size' => size,
+        'authenticated' => authenticated,
+        'actions' => {
+          'upload' => {
+            'href' => object.presigned_url(:put, acl: 'public-read', :expires_in => 86400)
+          }
+        },
+        'expires_at' => DateTime.now.next_day.to_time.utc.iso8601
+      }
+    end
+
+    def object_error(error, message, object, object_json)
+      {
+        'oid' => object_json[:oid],
+        'size' => object_json[:size],
+        'error' => {
+          'code' => error,
+          'message' => message
+        }
+      }
+    end
+
+    def download(authenticated, params)
+      objects = Array.new
+      params[:objects].each do |object_json|
+        object_json = indifferent_params object_json
+        object = object_data object_json[:oid]
+        if valid_object? object_json
+          if object.exists?
+            objects.push object_download(authenticated, object, object_json)
+          else
+            objects.push object_error(404, 'Object does not exist', object, object_json)
+          end
+        else
+          objects.push object_error(422, 'Validation error', object, object_json)
+        end
+      end
+      objects
+    end
+
+    def upload(authenticated, params)
+      objects = Array.new
+      params[:objects].each do |object_json|
+        object_json = indifferent_params object_json
+        object = object_data object_json[:oid]
+        if valid_object? object_json
+          if object.exists?
+            objects.push object_download(authenticated, object, object_json)
+          else
+            objects.push object_upload(authenticated, object, object_json)
+          end
+        else
+          objects.push object_error(422, 'Validation error', object, object_json)
+        end
+      end
+      objects
+    end
+
+    def lfs_resp(objects)
+      status 200
+      resp = {
+        'transfer' => 'basic',
+        'objects' => objects
+      }
+      logger.debug resp
+      body MultiJson.dump(resp)
+    end
+    
+    def error_resp(status_code, message)
+      status status_code
+      resp = {
+        'message' => message,
+        'request_id' => SecureRandom::uuid
+      }
+      logger.debug resp
+      body MultiJson.dump(resp)
+    end
+    
+    post '/objects/batch', provides: 'application/vnd.git-lfs+json' do
+      # Git LFS Batch API
+      authenticated = authorized?
+      params = indifferent_params(JSON.parse(request.body.read))
+      
+      if params[:operation] == 'download'
+        objects = download(authenticated, params)
+      elsif params[:operation] == 'upload'
+        if authenticated
+          objects = upload(authenticated, params)
+        else
+          objects = nil
+        end
+      end
+      
+      if objects
+        lfs_resp(objects)
+      else
+        error_resp(401, 'Credentials needed')
+      end
+    end
+
     get "/objects/:oid", provides: 'application/vnd.git-lfs+json' do
       object = object_data(params[:oid])
 
@@ -93,6 +234,16 @@ module GitLfsS3
       status service.status
       body MultiJson.dump(service.response)
     end
+
+    post "/objects/batch", provides: 'application/vnd.git-lfs+json' do
+      logger.debug headers.inspect
+      service = UploadBatchService.service_for(request.body)
+      logger.debug service.response
+      
+      status service.status
+      body MultiJson.dump(service.response)
+    end
+
 
     post '/verify', provides: 'application/vnd.git-lfs+json' do
       data = MultiJson.load(request.body.tap { |b| b.rewind }.read)

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -72,12 +72,12 @@ module GitLfsS3
         'size'          => size,
         'authenticated' => authenticated,
         'actions'       => {
-          'download'  => {
-            'href'  => obj.presigned_url(:get,
-                                         :expires_in => 86400),
+          'download'      => {
+            'href'          => obj.presigned_url(:get,
+                                                 :expires_in => 86400),
+            'expires_at'    => expire_at,
           },
         },
-        'expires_at'    => expire_at,
       }
     end
 
@@ -90,12 +90,12 @@ module GitLfsS3
         'size'          => size,
         'authenticated' => authenticated,
         'actions'       => {
-          'upload'    => {
-            'href'  => obj.presigned_url(:put,
-                                         acl: 'public-read',
-                                         :expires_in => 86400),
+          'upload'        => {
+            'href'          => obj.presigned_url(:put,
+                                                 acl: 'public-read',
+                                                 :expires_in => 86400),
+            'expires_at'    => expire_at,
           },
-          'expires_at'  => expire_at,
         },
       }
     end
@@ -106,8 +106,8 @@ module GitLfsS3
         'oid'         => obj_json[:oid],
         'size'        => obj_json[:size],
         'error'       => {
-          'code'    => error,
-          'message' => message,
+          'code'        => error,
+          'message'     => message,
         },
       }
     end
@@ -181,7 +181,9 @@ module GitLfsS3
         end
       elsif params[:operation] == 'upload'
         if authenticated
-          lfs_resp(upload(authenticated, params))
+          resp = lfs_resp(upload(authenticated, params))
+          logger.debug resp
+          resp
         else
           error_resp(401, 'Credentials needed')
         end

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -72,9 +72,9 @@ module GitLfsS3
         'size'          => size,
         'authenticated' => authenticated,
         'actions'       => {
-          'download'    => {
-            'href'      => obj.presigned_url(:get,
-                                             :expires_in => 86400),
+          'download'  => {
+            'href'  => obj.presigned_url(:get,
+                                         :expires_in => 86400),
           },
         },
         'expires_at'    => expire_at,
@@ -90,10 +90,10 @@ module GitLfsS3
         'size'          => size,
         'authenticated' => authenticated,
         'actions'       => {
-          'upload'      => {
-            'href'      => obj.presigned_url(:put,
-                                             acl: 'public-read',
-                                             :expires_in => 86400),
+          'upload'    => {
+            'href'  => obj.presigned_url(:put,
+                                         acl: 'public-read',
+                                         :expires_in => 86400),
           },
           'expires_at'  => expire_at,
         },
@@ -103,9 +103,9 @@ module GitLfsS3
     def obj_error(error, message, obj_json)
       # Format a single error object.
       {
-        'oid'       => obj_json[:oid],
-        'size'      => obj_json[:size],
-        'error'     => {
+        'oid'         => obj_json[:oid],
+        'size'        => obj_json[:size],
+        'error'       => {
           'code'    => error,
           'message' => message,
         },
@@ -118,7 +118,7 @@ module GitLfsS3
       params[:objects].each do |obj_json|
         obj_json = indifferent_params(obj_json)
         obj = object_data(obj_json[:oid])
-        if valid_object?(obj_json)
+        if valid_obj?(obj_json)
           if obj.exists?
             objects.push(obj_download(authenticated, obj, obj_json))
           else
@@ -176,13 +176,11 @@ module GitLfsS3
       params = indifferent_params(JSON.parse(request.body.read))
       logger.debug params
       if params[:operation] == 'download'
-        objects = download(authenticated, params)
+        lfs_resp(download(authenticated, params))
       elsif params[:operation] == 'upload'
         if authenticated
-          objects = upload(authenticated, params)
-          lfs_resp(objects)
+          lfs_resp(upload(authenticated, params))
         else
-          objects = nil
           error_resp(401, 'Credentials needed')
         end
       else

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -67,6 +67,7 @@ module GitLfsS3
     end
 
     def object_download(authenticated, object, object_json)
+      # Format a single download object.
       oid = object_json[:oid]
       size = object_json[:size]
       {
@@ -100,6 +101,7 @@ module GitLfsS3
     end
 
     def object_error(error, message, object, object_json)
+      # Format a single error object.
       {
         'oid' => object_json[:oid],
         'size' => object_json[:size],
@@ -111,6 +113,7 @@ module GitLfsS3
     end
 
     def download(authenticated, params)
+      # Handle git-lfs batch downloads.
       objects = Array.new
       params[:objects].each do |object_json|
         object_json = indifferent_params object_json
@@ -129,6 +132,7 @@ module GitLfsS3
     end
 
     def upload(authenticated, params)
+      # Handle git-lfs batch uploads.
       objects = Array.new
       params[:objects].each do |object_json|
         object_json = indifferent_params object_json
@@ -147,6 +151,7 @@ module GitLfsS3
     end
 
     def lfs_resp(objects)
+      # Successful git-lfs batch response.
       status 200
       resp = {
         'transfer' => 'basic',
@@ -157,6 +162,7 @@ module GitLfsS3
     end
     
     def error_resp(status_code, message)
+      # Error git-lfs batch response.
       status status_code
       resp = {
         'message' => message,
@@ -167,7 +173,7 @@ module GitLfsS3
     end
     
     post '/objects/batch', provides: 'application/vnd.git-lfs+json' do
-      # Git LFS Batch API
+      # git-lfs batch API
       authenticated = authorized?
       params = indifferent_params(JSON.parse(request.body.read))
       

--- a/lib/git-lfs-s3/application.rb
+++ b/lib/git-lfs-s3/application.rb
@@ -178,6 +178,10 @@ module GitLfsS3
       if params[:operation] == 'download'
         if settings.public_server
           lfs_resp(download(authenticated, params))
+        elsif authenticated
+          lfs_resp(download(authenticated, params))
+        else
+          error_resp(401, 'Credentials needed')
         end
       elsif params[:operation] == 'upload'
         if authenticated

--- a/lib/git-lfs-s3/services/upload/object_exists.rb
+++ b/lib/git-lfs-s3/services/upload/object_exists.rb
@@ -9,7 +9,7 @@ module GitLfsS3
         {
           '_links' => {
             'download' => {
-              'href' => object.presigned_url(:get)
+              'href' => object.presigned_url(:get, :expires_in => 86400)
             }
           }
         }

--- a/lib/git-lfs-s3/services/upload/upload_required.rb
+++ b/lib/git-lfs-s3/services/upload/upload_required.rb
@@ -32,9 +32,9 @@ module GitLfsS3
           GitLfsS3::CephPresignerService::signed_url(object)
         else
           if GitLfsS3::Application.settings.public_server
-            object.presigned_url(:put, acl: 'public-read')
+            object.presigned_url(:put, acl: 'public-read', :expires_in => 86400)
           else
-            object.presigned_url(:put)
+            object.presigned_url(:put, :expires_in => 86400)
           end
         end
       end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.2.6'
+  VERSION = '0.3.0'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.3.3'
+  VERSION = '0.3.4'
 end

--- a/lib/git-lfs-s3/version.rb
+++ b/lib/git-lfs-s3/version.rb
@@ -1,3 +1,3 @@
 module GitLfsS3
-  VERSION = '0.3.1'
+  VERSION = '0.3.3'
 end


### PR DESCRIPTION
  * Implement [Git LFS Batch API](https://github.com/git-lfs/git-lfs/blob/master/docs/api/batch.md).
  * Incremented version to 0.3.4.
  * Added 1 day expiration for upload and download URLs.
  * The Legacy Git LFS API remains.


	modified:   git-lfs-s3.gemspec
	modified:   lib/git-lfs-s3/application.rb
	modified:   lib/git-lfs-s3/services/upload/object_exists.rb
	modified:   lib/git-lfs-s3/services/upload/upload_required.rb
	modified:   lib/git-lfs-s3/version.rb