### PR TITLE
bump sinatra dep to ~> 2

### DIFF
--- a/git-lfs-s3.gemspec
+++ b/git-lfs-s3.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'aws-sdk', '~> 2'
-  gem.add_dependency 'sinatra', '~> 1'
+  gem.add_dependency 'sinatra', '~> 2'
   gem.add_dependency 'multi_json', '~> 1'
 
   gem.add_development_dependency 'rake', '~> 10'


### PR DESCRIPTION
Sinatra >= 2 is needed to upgrade to rack >= 2, which is required for
rack-protection >= 2.

See: https://nvd.nist.gov/vuln/detail/CVE-2018-1000119